### PR TITLE
Add bytes type in proto for audio and test client autoresampling

### DIFF
--- a/proto/speech.proto
+++ b/proto/speech.proto
@@ -7,7 +7,7 @@ option go_package = "example.com/speechpb;speechpb";
 
 // (float array) 
 message AudioChunk {
-  repeated float samples = 1;
+  bytes audio_bytes = 1;
   // timestamp can be used to align the audio chunks and testing
 }
 

--- a/src/server/stream_session.py
+++ b/src/server/stream_session.py
@@ -66,7 +66,7 @@ class WhispStreamSession(StreamSession):
         try:
             async for audio_chunk in request_iterator:
                 audio_samples = np.frombuffer(audio_chunk.audio_bytes, dtype=np.float32)
-                await self.processor_manager.audio_queue.put(audio_samples) # TODO: change audio_chunk.samples
+                await self.processor_manager.audio_queue.put(audio_samples)
         except Exception as e:
             self.processor_manager.logger.error(f"Exception in request_enqueuer {self.processor_manager.id}: {e}")
 

--- a/src/server/stream_session.py
+++ b/src/server/stream_session.py
@@ -65,12 +65,16 @@ class WhispStreamSession(StreamSession):
     async def request_enqueuer(self, request_iterator):
         try:
             async for audio_chunk in request_iterator:
-                await self.processor_manager.audio_queue.put(audio_chunk.samples)
+                audio_samples = np.frombuffer(audio_chunk.audio_bytes, dtype=np.float32)
+                await self.processor_manager.audio_queue.put(audio_samples) # TODO: change audio_chunk.samples
         except Exception as e:
             self.processor_manager.logger.error(f"Exception in request_enqueuer {self.processor_manager.id}: {e}")
 
-    async def manage_first_message(self, first_request):
-        await self.processor_manager.insert_audio(first_request.samples)
+    # this method is called to handle the first message of the stream session.
+    # purpose is allow the session to handle eventual configuration messages in the future. with easier extensibility for more session types.
+    async def manage_first_message(self, first_request): 
+        audio_samples = np.frombuffer(first_request.audio_bytes, dtype=np.float32)
+        await self.processor_manager.insert_audio(audio_samples) 
 
 class StandardWhispStreamSession(WhispStreamSession):
     """

--- a/src/server/stream_utils.py
+++ b/src/server/stream_utils.py
@@ -3,6 +3,7 @@ import sys
 import logging
 import asyncio
 import numpy as np
+from typing import Iterable, Optional
 from datetime import datetime
 from contextlib import asynccontextmanager
 from src.parallel_whisper_online import ParallelOnlineASRProcessor
@@ -55,13 +56,13 @@ class ProcessorManager:
         self.audio_queue = asyncio.Queue()
         self._shared_asr = shared_asr 
 
-    async def insert_audio(self, already_collected_chunks=None):
+    async def insert_audio(self, already_collected_chunks: Optional[Iterable[float]] = None):
         """
         Insert the audio chunks collected by the async audio_queue into the processor.
         If a chunk was already collected, it will be inserted into the processor.
         """
         audio_batch = []
-        if already_collected_chunks:
+        if already_collected_chunks is not None:
             audio_batch.extend(already_collected_chunks)
 
         while not self.audio_queue.empty():


### PR DESCRIPTION
## Changes
* **Refers to #11**
* Use the `bytes` field in Protocol Buffers 3 to exchange audio chunks as raw byte strings.
* Add automatic resampling in the test client when the selected `sounddevice` input does not support 16 kHz natively.
* Add support for selecting the `sounddevice` input device by ID in the test client, in case the default device is incorrect or non-functional.